### PR TITLE
Remove unnecessary list conversion

### DIFF
--- a/käännä.py
+++ b/käännä.py
@@ -16,7 +16,7 @@ class Kääntäjä:
 	def käännä(self, teksti):
 		nlp = SPACY_MODELS[self.src]
 		doc = nlp(teksti)
-		lauseet = list(map(str, doc.sents))
+		lauseet = map(str, doc.sents)
 		return " ".join(self.translator(lause)[0]["translation_text"] for lause in lauseet)
 
 


### PR DESCRIPTION
The map function returns an iterable and there is no need to convert it
to a list because all we're interested in is iterating over the contents
of the return value.